### PR TITLE
Remove setup.py use_2to3 arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     url="https://github.com/readevalprint/sneklang",
     keywords=["sandbox", "parse", "ast"],
     test_suite="test_snek",
-    use_2to3=True,
     install_requires=["pytest", "ConfigArgParse", "python-forge"],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Newer versions of setuptools no longer support `use_2to3` and will throw an error on install.